### PR TITLE
SettingsProvider: turn off mobile data roaming by default

### DIFF
--- a/packages/SettingsProvider/res/values/customize.xml
+++ b/packages/SettingsProvider/res/values/customize.xml
@@ -96,7 +96,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <string name="def_input_method" translatable="false"></string>
 
     <!-- Default for Settings.Global.DATA_ROAMING -->
-    <bool name="def_enable_data_roaming">true</bool>
+    <bool name="def_enable_data_roaming">false</bool>
 
     <!-- Default for Settings.Global.MOBILE_DATA -->
     <bool name="def_enable_mobile_data">true</bool>


### PR DESCRIPTION
Commit 23a9f51caf09642783ff004db9fd5f168fcab14d moved the roaming data property from
a system property to xml config, but inadvertantly switched the default from false
to true.  This fixes it by making the default false again.

Change-Id: I25b7666a5c0b638992e8203621daca6c860c91b2